### PR TITLE
🚑 Hotfix because go-swagger doesn't understand x-alternatives

### DIFF
--- a/client/openapi.json
+++ b/client/openapi.json
@@ -16911,11 +16911,9 @@
     "prerelease": {
       "type": "array",
       "items": {
-        "type": "string",
-        "example": "alpha",
-        "x-alternatives": [
-          { "type": "string", "example": "alpha" },
-          { "type": "number", "example": 1 }
+        "oneOf": [
+          {"type": "string"},
+          {"type": "number"}
         ]
       }
     },

--- a/models/prerelease.go
+++ b/models/prerelease.go
@@ -14,7 +14,7 @@ import (
 // Prerelease prerelease
 //
 // swagger:model prerelease
-type Prerelease []string
+type Prerelease []interface{}
 
 // Validate validates this prerelease
 func (m Prerelease) Validate(formats strfmt.Registry) error {


### PR DESCRIPTION
Well apparently unms is doing what is described in x-alternatives...unfortunately go-swagger doesn't seem to support it. I experimented with TypeMapping in GenOpts but it doesn't seem to do anything (or I don't understand it).

So this is just a hotfix to make it work again for now :S