### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM golang:1.18 AS build
+FROM golang:1.18-alpine AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
+ENV CGO_ENABLED=0
+
 COPY . ./
-RUN go build -o unms-exporter main.go
+RUN go build -ldflags="-s -w" -trimpath -o unms-exporter main.go
 
-FROM ubuntu:20.04
+FROM alpine
 
-RUN apt-get -q update && apt-get -yq install ca-certificates
+RUN apk add --no-cache tzdata ca-certificates
 COPY --from=build /src/unms-exporter /usr/local/bin/
 
 CMD ["/usr/local/bin/unms-exporter"]


### PR DESCRIPTION
By using Alpine instead of Ubuntu, the resulting image is around 110 MB smaller:

    $ docker images
    REPOSITORY       TAG      CREATED         SIZE
    unms-exporter    alpine   3 seconds ago   20MB
    unms-exporter    ubuntu   5 minutes ago   132MB

Some savings are due to building with `-ldflags="-s -w"` (strip binary), and `-trimpath` (remove builder path prefixes).

We could save 5 MB more by using `FROM scratch` instead of Alpine, but then handling of timezone and CA certificate files becomes a hassle.